### PR TITLE
fixed: react-split: children prop should be an array

### DIFF
--- a/packages/react-split/src/index.js
+++ b/packages/react-split/src/index.js
@@ -158,7 +158,7 @@ SplitWrapper.propTypes = {
     onDragStart: PropTypes.func,
     onDragEnd: PropTypes.func,
     collapsed: PropTypes.bool,
-    children: PropTypes.element,
+    children: PropTypes.arrayOf(PropTypes.element),
 }
 
 SplitWrapper.defaultProps = {


### PR DESCRIPTION
Small fix for #169 