### PR TITLE
Fix setting sizes dynamically from props and state

### DIFF
--- a/packages/react-split/src/index.js
+++ b/packages/react-split/src/index.js
@@ -65,7 +65,7 @@ class SplitWrapper extends React.Component {
         // Destroy and re-create split if options changed
         if (needsRecreate) {
             options.minSize = minSize
-            options.sizes = sizes
+            options.sizes = sizes || this.split.getSizes()
             this.split.destroy(true, true)
             options.gutter = (index, direction, pairB) => pairB.previousSibling
             this.split = Split(

--- a/packages/react-split/src/index.js
+++ b/packages/react-split/src/index.js
@@ -65,7 +65,7 @@ class SplitWrapper extends React.Component {
         // Destroy and re-create split if options changed
         if (needsRecreate) {
             options.minSize = minSize
-            options.sizes = this.split.getSizes()
+            options.sizes = sizes
             this.split.destroy(true, true)
             options.gutter = (index, direction, pairB) => pairB.previousSibling
             this.split = Split(


### PR DESCRIPTION
There is a discrepancy between when a split needs to be recreated and when just an update is needed. In the former case, current split sizes are used, while the sizes from the props should be used. When just resizing an existing split, the correct sizes are used. This PR corrects this inconsistency.