### PR TITLE
Parsing of CSS variables

### DIFF
--- a/packages/grid-template-utils/src/index.js
+++ b/packages/grid-template-utils/src/index.js
@@ -1,6 +1,6 @@
 const numeric = (value, unit) => Number(value.slice(0, -1 * unit.length))
 
-const parseValue = value => {
+const parseValue = (value, element) => {
     if (value.endsWith('px'))
         return { value, type: 'px', numeric: numeric(value, 'px') }
     if (value.endsWith('fr'))
@@ -8,10 +8,12 @@ const parseValue = value => {
     if (value.endsWith('%'))
         return { value, type: '%', numeric: numeric(value, '%') }
     if (value === 'auto') return { value, type: 'auto' }
+    if (value.startsWith('var(') && element)
+        return parseValue(getComputedStyle(element).getPropertyValue(value.slice(4, -1)))
     return null
 }
 
-export const parse = rule => rule.split(' ').map(parseValue)
+export const parse = (rule, element) => rule.split(' ').map((v)=>{ return parseValue(v, element) })
 
 export const combine = (rule, tracks) => {
     const prevTracks = rule ? rule.split(' ') : []

--- a/packages/split-grid/src/index.js
+++ b/packages/split-grid/src/index.js
@@ -160,12 +160,12 @@ class Gutter {
 
     setTracks(raw) {
         this.tracks = raw.split(' ')
-        this.trackValues = parse(raw)
+        this.trackValues = parse(raw, this.element)
     }
 
     setComputedTracks(raw) {
         this.computedTracks = raw.split(' ')
-        this.computedPixels = parse(raw)
+        this.computedPixels = parse(raw, this.element)
     }
 
     setGap(raw) {


### PR DESCRIPTION
I had a bug when Split tried to parse the `grid-template-columns` or `grid-template-rows` properties of my grid due to the presence of css variables. 
Just solved it and wanted to share.

Thanks for the hard work !