### PR TITLE
fix: index gutters using track number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist/
 node_modules/
 yarn-error.log
+.history/

--- a/packages/split-grid/src/index.js
+++ b/packages/split-grid/src/index.js
@@ -503,14 +503,14 @@ class Grid {
         }
 
         this.options.columnGutters.forEach(gutterOptions => {
-            this.columnGutters[options.track] = createGutter(
+            this.columnGutters[gutterOptions.track] = createGutter(
                 'column',
                 this.options,
             )(gutterOptions)
         })
 
         this.options.rowGutters.forEach(gutterOptions => {
-            this.rowGutters[options.track] = createGutter('row', this.options)(
+            this.rowGutters[gutterOptions.track] = createGutter('row', this.options)(
                 gutterOptions,
             )
         })

--- a/packages/split-grid/src/index.test.js
+++ b/packages/split-grid/src/index.test.js
@@ -1,0 +1,30 @@
+/* eslint-env jest */
+
+import Split from './index'
+
+const gutter1 = { id: 'gutter1', addEventListener() {} }
+const gutter2 = { id: 'gutter2', addEventListener() {} }
+const gutter3 = { id: 'gutter3', addEventListener() {} }
+const gutters = [
+    { track: 1, element: gutter1 },
+    { track: 3, element: gutter2 },
+    { track: 5, element: gutter3 },
+]
+
+test('Grid#constructor columnGutters', () => {
+    const res = Split({
+        columnGutters: gutters,
+    })
+    expect(res.columnGutters[1].element.id).toEqual(gutter1.id)
+    expect(res.columnGutters[3].element.id).toEqual(gutter2.id)
+    expect(res.columnGutters[5].element.id).toEqual(gutter3.id)
+})
+
+test('Grid#constructor rowGutters', () => {
+    const res = Split({
+        rowGutters: gutters,
+    })
+    expect(res.rowGutters[1].element.id).toEqual(gutter1.id)
+    expect(res.rowGutters[3].element.id).toEqual(gutter2.id)
+    expect(res.rowGutters[5].element.id).toEqual(gutter3.id)
+})


### PR DESCRIPTION
Thank you for this awesome library! I ran into a small issue while using `split-grid`. Please let me know if you have any questions

In the `Grid` constructor, gutters are indexed by the `options.track` property, but there is no such property in the `options` object passed in to the constructor. So, each gutter is either assigned to `this.columnGutters[undefined]` or `this.rowGutters[undefined]`. These changes use the `track` provided for each gutter (`gutterOptions.track`) to index the gutters added to the `rowGutters` and `columnGutters` objects.