### PR TITLE
Update direction class name on component update

### DIFF
--- a/packages/react-split/src/index.js
+++ b/packages/react-split/src/index.js
@@ -67,7 +67,10 @@ class SplitWrapper extends React.Component {
             options.minSize = minSize
             options.sizes = sizes || this.split.getSizes()
             this.split.destroy(true, true)
-            options.gutter = (index, direction, pairB) => pairB.previousSibling
+            options.gutter = (index, direction, pairB) => {
+                pairB.previousSibling.className = `gutter gutter-${direction}`
+                return pairB.previousSibling
+            }
             this.split = Split(
                 Array.from(this.parent.children).filter(
                     // eslint-disable-next-line no-underscore-dangle


### PR DESCRIPTION
Currently, when you change the `direction` being passed to the Split component, the className of the rendered element does not change to match.  This fixes that problem by reassigning className on component update.