### PR TITLE
Unrestrict cursor option typing

### DIFF
--- a/packages/splitjs/index.d.ts
+++ b/packages/splitjs/index.d.ts
@@ -42,7 +42,7 @@ declare namespace Split {
     direction?: 'horizontal' | 'vertical';
 
     // Cursor to display while dragging.
-    cursor?: 'col-resize' | 'row-resize';
+    cursor?: string;
 
     // Callback on drag.
     onDrag?(): void;


### PR DESCRIPTION
There doesn't appear to be a restriction in the code that limits the cursor style to one of col-resize or row-resize.
Changed it to string to be more lenient, like gutterAlign.