### PR TITLE
Add support for dynamically adding children and null children fix

### DIFF
--- a/packages/react-split/package.json
+++ b/packages/react-split/package.json
@@ -16,9 +16,7 @@
   "repository": "https://github.com/nathancahill/split",
   "author": "Nathan Cahill <nathan@nathancahill.com>",
   "homepage": "https://split.js.org/",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "MIT",
   "dependencies": {
     "lodash.isequal": "^4.5.0",

--- a/packages/react-split/package.json
+++ b/packages/react-split/package.json
@@ -1,32 +1,35 @@
 {
-  "name": "react-split",
-  "version": "2.0.7",
-  "description": "React component for Split.js",
-  "main": "dist/react-split.js",
-  "minified:main": "dist/react-split.min.js",
-  "module": "dist/react-split.es.js",
-  "scripts": {
-    "prepublish": "rollup -c",
-    "build": "rollup -c && npm run size",
-    "watch": "rollup -cw",
-    "test": "jest",
-    "lint": "eslint src",
-    "size": "echo \"gzip size: $(gzip-size --raw $npm_package_minified_main) bytes\""
-  },
-  "repository": "https://github.com/nathancahill/split",
-  "author": "Nathan Cahill <nathan@nathancahill.com>",
-  "homepage": "https://split.js.org/",
-  "files": ["dist"],
-  "license": "MIT",
-  "dependencies": {
-    "prop-types": "^15.5.7",
-    "split.js": "^1.5.9"
-  },
-  "peerDependencies": {
-    "react": ">=15.4.2 || >= 16.0.0"
-  },
-  "collective": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/splitjs"
-  }
+    "name": "react-split",
+    "version": "2.0.7",
+    "description": "React component for Split.js",
+    "main": "dist/react-split.js",
+    "minified:main": "dist/react-split.min.js",
+    "module": "dist/react-split.es.js",
+    "scripts": {
+        "prepublish": "rollup -c",
+        "build": "rollup -c && npm run size",
+        "watch": "rollup -cw",
+        "test": "jest",
+        "lint": "eslint src",
+        "size": "echo \"gzip size: $(gzip-size --raw $npm_package_minified_main) bytes\""
+    },
+    "repository": "https://github.com/nathancahill/split",
+    "author": "Nathan Cahill <nathan@nathancahill.com>",
+    "homepage": "https://split.js.org/",
+    "files": [
+        "dist"
+    ],
+    "license": "MIT",
+    "dependencies": {
+        "lodash.xor": "^4.5.0",
+        "prop-types": "^15.5.7",
+        "split.js": "^1.5.9"
+    },
+    "peerDependencies": {
+        "react": ">=15.4.2 || >= 16.0.0"
+    },
+    "collective": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/splitjs"
+    }
 }

--- a/packages/react-split/package.json
+++ b/packages/react-split/package.json
@@ -1,35 +1,35 @@
 {
-    "name": "react-split",
-    "version": "2.0.7",
-    "description": "React component for Split.js",
-    "main": "dist/react-split.js",
-    "minified:main": "dist/react-split.min.js",
-    "module": "dist/react-split.es.js",
-    "scripts": {
-        "prepublish": "rollup -c",
-        "build": "rollup -c && npm run size",
-        "watch": "rollup -cw",
-        "test": "jest",
-        "lint": "eslint src",
-        "size": "echo \"gzip size: $(gzip-size --raw $npm_package_minified_main) bytes\""
-    },
-    "repository": "https://github.com/nathancahill/split",
-    "author": "Nathan Cahill <nathan@nathancahill.com>",
-    "homepage": "https://split.js.org/",
-    "files": [
-        "dist"
-    ],
-    "license": "MIT",
-    "dependencies": {
-        "lodash.xor": "^4.5.0",
-        "prop-types": "^15.5.7",
-        "split.js": "^1.5.9"
-    },
-    "peerDependencies": {
-        "react": ">=15.4.2 || >= 16.0.0"
-    },
-    "collective": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/splitjs"
-    }
+  "name": "react-split",
+  "version": "2.0.7",
+  "description": "React component for Split.js",
+  "main": "dist/react-split.js",
+  "minified:main": "dist/react-split.min.js",
+  "module": "dist/react-split.es.js",
+  "scripts": {
+    "prepublish": "rollup -c",
+    "build": "rollup -c && npm run size",
+    "watch": "rollup -cw",
+    "test": "jest",
+    "lint": "eslint src",
+    "size": "echo \"gzip size: $(gzip-size --raw $npm_package_minified_main) bytes\""
+  },
+  "repository": "https://github.com/nathancahill/split",
+  "author": "Nathan Cahill <nathan@nathancahill.com>",
+  "homepage": "https://split.js.org/",
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "lodash.isequal": "^4.5.0",
+    "prop-types": "^15.5.7",
+    "split.js": "^1.5.9"
+  },
+  "peerDependencies": {
+    "react": ">=15.4.2 || >= 16.0.0"
+  },
+  "collective": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/splitjs"
+  }
 }

--- a/packages/react-split/rollup.config.js
+++ b/packages/react-split/rollup.config.js
@@ -17,6 +17,7 @@ export default [
                     react: 'React',
                     'prop-types': 'PropTypes',
                     'split.js': 'Split',
+                    'lodash.isequal': 'lodash.isequal',
                 },
             },
             {
@@ -25,7 +26,7 @@ export default [
                 sourcemap: false,
             },
         ],
-        external: ['split.js', 'react', 'prop-types'],
+        external: ['split.js', 'react', 'prop-types', 'lodash.isequal'],
         plugins: [
             buble({
                 exclude: 'node_modules/**',
@@ -48,9 +49,10 @@ export default [
                 react: 'React',
                 'prop-types': 'PropTypes',
                 'split.js': 'Split',
+                'lodash.isequal': 'lodash.isequal',
             },
         },
-        external: ['split.js', 'react', 'prop-types'],
+        external: ['split.js', 'react', 'prop-types', 'lodash.isequal'],
         plugins: [
             buble({
                 exclude: 'node_modules/**',

--- a/packages/react-split/src/index.js
+++ b/packages/react-split/src/index.js
@@ -22,7 +22,8 @@ class SplitWrapper extends React.Component {
         } = prevProps
 
         const childrenChanged =
-            sizes.length !== prevSizes.length || !equal(children, prevChildren)
+            (sizes && prevSizes && sizes.length !== prevSizes.length) ||
+            !equal(children, prevChildren)
 
         const otherProps = [
             'expandToMin',

--- a/packages/react-split/src/index.js
+++ b/packages/react-split/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Split from 'split.js'
-import xor from 'lodash.xor'
+import equal from 'lodash.isequal'
 
 class SplitWrapper extends React.Component {
     componentDidMount() {
@@ -20,7 +20,9 @@ class SplitWrapper extends React.Component {
             collapsed: prevCollapsed,
             children: prevChildren,
         } = prevProps
-        const sizesLengthChanged = xor(children, prevChildren).length !== 0
+
+        const childrenChanged =
+            sizes.length !== prevSizes.length || !equal(children, prevChildren)
 
         const otherProps = [
             'expandToMin',
@@ -35,7 +37,7 @@ class SplitWrapper extends React.Component {
         let needsRecreate = otherProps
             // eslint-disable-next-line react/destructuring-assignment
             .map(prop => this.props[prop] !== prevProps[prop])
-            .reduce((accum, same) => accum || same, sizesLengthChanged)
+            .reduce((accum, same) => accum || same, childrenChanged)
 
         // Compare minSize when both are arrays, when one is an array and when neither is an array
         if (Array.isArray(minSize) && Array.isArray(prevMinSize)) {
@@ -54,7 +56,7 @@ class SplitWrapper extends React.Component {
 
         // Destroy and re-create split if options changed
         if (needsRecreate) {
-            if (sizesLengthChanged) {
+            if (childrenChanged) {
                 options.sizes = sizes
             } else {
                 options.sizes = this.split.getSizes()
@@ -62,7 +64,7 @@ class SplitWrapper extends React.Component {
                     pairB.previousSibling
             }
             options.minSize = minSize
-            this.split.destroy(true, !sizesLengthChanged)
+            this.split.destroy(true, !childrenChanged)
             this.split = Split(
                 Array.from(this.parent.children).filter(
                     // eslint-disable-next-line no-underscore-dangle

--- a/packages/react-split/src/index.js
+++ b/packages/react-split/src/index.js
@@ -1,25 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Split from 'split.js'
+import xor from 'lodash.xor'
 
 class SplitWrapper extends React.Component {
     componentDidMount() {
         const { children, gutter, ...options } = this.props
 
-        options.gutter = (index, direction) => {
-            let gutterElement
-
-            if (gutter) {
-                gutterElement = gutter(index, direction)
-            } else {
-                gutterElement = document.createElement('div')
-                gutterElement.className = `gutter gutter-${direction}`
-            }
-
-            // eslint-disable-next-line no-underscore-dangle
-            gutterElement.__isSplitGutter = true
-            return gutterElement
-        }
+        options.gutter = this.getGutterElement(gutter)
 
         this.split = Split(this.parent.children, options)
     }
@@ -30,7 +18,9 @@ class SplitWrapper extends React.Component {
             minSize: prevMinSize,
             sizes: prevSizes,
             collapsed: prevCollapsed,
+            children: prevChildren,
         } = prevProps
+        const sizesLengthChanged = xor(children, prevChildren).length !== 0
 
         const otherProps = [
             'expandToMin',
@@ -45,7 +35,7 @@ class SplitWrapper extends React.Component {
         let needsRecreate = otherProps
             // eslint-disable-next-line react/destructuring-assignment
             .map(prop => this.props[prop] !== prevProps[prop])
-            .reduce((accum, same) => accum || same, false)
+            .reduce((accum, same) => accum || same, sizesLengthChanged)
 
         // Compare minSize when both are arrays, when one is an array and when neither is an array
         if (Array.isArray(minSize) && Array.isArray(prevMinSize)) {
@@ -64,10 +54,15 @@ class SplitWrapper extends React.Component {
 
         // Destroy and re-create split if options changed
         if (needsRecreate) {
+            if (sizesLengthChanged) {
+                options.sizes = sizes
+            } else {
+                options.sizes = this.split.getSizes()
+                options.gutter = (index, direction, pairB) =>
+                    pairB.previousSibling
+            }
             options.minSize = minSize
-            options.sizes = sizes || this.split.getSizes()
-            this.split.destroy(true, true)
-            options.gutter = (index, direction, pairB) => pairB.previousSibling
+            this.split.destroy(true, !sizesLengthChanged)
             this.split = Split(
                 Array.from(this.parent.children).filter(
                     // eslint-disable-next-line no-underscore-dangle
@@ -101,6 +96,24 @@ class SplitWrapper extends React.Component {
     componentWillUnmount() {
         this.split.destroy()
         delete this.split
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    getGutterElement(customGutterFunction) {
+        return (index, direction, pairElement) => {
+            let gutter
+
+            if (customGutterFunction) {
+                gutter = customGutterFunction(index, direction, pairElement)
+            } else {
+                gutter = document.createElement('div')
+                gutter.className = `gutter gutter-${direction}`
+            }
+
+            // eslint-disable-next-line no-underscore-dangle
+            gutter.__isSplitGutter = true
+            return gutter
+        }
     }
 
     render() {


### PR DESCRIPTION
I've been using split for a bit now and ran into the issue of not being able to dynamically add children, so I pulled in the changes from #181 . 

I also noticed an issue where if I have multiple children and any of them are null (i.e. `[Button, null]`), even if they become non-null (i.e. `[Button, Button])`, Split will not create a new gutter.

