### PR TITLE
Fix element.element parent insertBefore error

### DIFF
--- a/packages/splitjs/src/split.js
+++ b/packages/splitjs/src/split.js
@@ -638,7 +638,7 @@ const Split = (idsOption, options = {}) => {
                 pair[gutterStartDragging],
             )
 
-            parent.insertBefore(gutterElement, element.element)
+            element.element.parentElement.insertBefore(gutterElement, element.element)
 
             pair.gutter = gutterElement
         }


### PR DESCRIPTION
`Encountered Console Error`
Uncaught DOMException: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.

`Fix`
Use `element.element.parentElement` at the time of `insertBefore` instead of using a pre-declared `parent` 