### PR TITLE
split-grid: fix #213 - opening collapsed columns may fail

### DIFF
--- a/packages/split-grid/src/Gutter.js
+++ b/packages/split-grid/src/Gutter.js
@@ -194,30 +194,18 @@ class Gutter {
         this.setGap(this.getGap())
         this.setComputedGap(this.getRawComputedGap())
 
-        const trackPercentage = this.trackValues.filter(
-            track => track.type === '%',
-        )
-        const trackFr = this.trackValues.filter(track => track.type === 'fr')
-
-        this.totalFrs = trackFr.length
-
-        if (this.totalFrs) {
-            const track = firstNonZero(trackFr)
-
-            if (track !== null) {
-                this.frToPixels =
-                    this.computedPixels[track].numeric / trackFr[track].numeric
-            }
+        const firstNonZeroFrTrack = firstNonZero('fr', this.trackValues)
+        if (firstNonZeroFrTrack !== null) {
+            this.frToPixels =
+                this.computedPixels[firstNonZeroFrTrack].numeric /
+                this.trackValues[firstNonZeroFrTrack].numeric
         }
 
-        if (trackPercentage.length) {
-            const track = firstNonZero(trackPercentage)
-
-            if (track !== null) {
-                this.percentageToPixels =
-                    this.computedPixels[track].numeric /
-                    trackPercentage[track].numeric
-            }
+        const firstNonZeroPercTrack = firstNonZero('%', this.trackValues)
+        if (firstNonZeroPercTrack !== null) {
+            this.percentageToPixels =
+                this.computedPixels[firstNonZeroPercTrack].numeric /
+                this.trackValues[firstNonZeroPercTrack].numeric
         }
 
         // get start of gutter track

--- a/packages/split-grid/src/util.js
+++ b/packages/split-grid/src/util.js
@@ -10,10 +10,10 @@ export const getGapValue = (unit, size) => {
     return null
 }
 
-export const firstNonZero = tracks => {
+export const firstNonZero = (type, tracks) => {
     // eslint-disable-next-line no-plusplus
     for (let i = 0; i < tracks.length; i++) {
-        if (tracks[i].numeric > 0) {
+        if (tracks[i].type === type && tracks[i].numeric > 0) {
             return i
         }
     }

--- a/packages/split-grid/src/util.test.js
+++ b/packages/split-grid/src/util.test.js
@@ -88,10 +88,46 @@ test('getGapValue', () => {
     expect(getGapValue('px', '10px')).toEqual(10)
 })
 
-test('firstNonZero first', () => {
-    expect(firstNonZero([{ numeric: 1 }, { numeric: 0 }])).toEqual(0)
+test('firstNonZero fraction first', () => {
+    expect(
+        firstNonZero('fr', [
+            { type: 'fr', numeric: 1 },
+            { type: 'fr', numeric: 0 },
+            { type: '%', numeric: 2 },
+            { type: '%', numeric: 0 },
+        ]),
+    ).toEqual(0)
 })
 
-test('firstNonZero second', () => {
-    expect(firstNonZero([{ numeric: 0 }, { numeric: 1 }])).toEqual(1)
+test('firstNonZero fraction second', () => {
+    expect(
+        firstNonZero('fr', [
+            { type: 'fr', numeric: 0 },
+            { type: 'fr', numeric: 1 },
+            { type: '%', numeric: 0 },
+            { type: '%', numeric: 1 },
+        ]),
+    ).toEqual(1)
+})
+
+test('firstNonZero percentage first', () => {
+    expect(
+        firstNonZero('%', [
+            { type: 'fr', numeric: 1 },
+            { type: 'fr', numeric: 0 },
+            { type: '%', numeric: 2 },
+            { type: '%', numeric: 0 },
+        ]),
+    ).toEqual(2)
+})
+
+test('firstNonZero percentage second', () => {
+    expect(
+        firstNonZero('%', [
+            { type: 'fr', numeric: 0 },
+            { type: 'fr', numeric: 1 },
+            { type: '%', numeric: 0 },
+            { type: '%', numeric: 1 },
+        ]),
+    ).toEqual(3)
 })


### PR DESCRIPTION
**Solution:** Instead of using a track index (`track` in the original code) retrieved by searching for a non-zero value in a filtered (potentially smaller!) array, this code gets the index from the actual trackValues array directly.
Because the outer if-loops surrounding the `..ToPixel`-calculations were redundant to begin with, I removed both them and the filtered track arrays.

Major kudos to @rassie for detecting the actual issue! I created a new PR since his (#319) failed some linting checks and because I had a slightly different direction in mind. I believe these changes better do justice to @nathancahill his codebase.

Originally I wanted to use Array.findIndex for the `firstNonZero`-function, but it looks like IE10 is still being used by Saucelabs to check the code, so I decided to stick to the original for-loop and not mess with it anymore than necessary.

Finally I updated the utility tests for to reflect the changes made to the `firstNonZero`-function.