### PR TITLE
Bind onDragStart and onDragEnd

### DIFF
--- a/packages/react-split-grid/src/index.js
+++ b/packages/react-split-grid/src/index.js
@@ -136,7 +136,7 @@ class ReactSplitGrid extends React.Component {
         }
     }
     
-    onDragEnd(direction, track, style) {
+    onDragEnd(direction, track) {
         const { onDragEnd } = this.props
 
         if (onDragEnd) {
@@ -217,6 +217,8 @@ ReactSplitGrid.propTypes = {
     columnMinSizes: PropTypes.arrayOf(PropTypes.number),
     rowMinSizes: PropTypes.arrayOf(PropTypes.number),
     onDrag: PropTypes.func,
+    onDragStart: PropTypes.func,
+    onDragEnd: PropTypes.func,
 }
 
 ReactSplitGrid.defaultProps = {
@@ -228,6 +230,8 @@ ReactSplitGrid.defaultProps = {
     columnMinSizes: undefined,
     rowMinSizes: undefined,
     onDrag: undefined,
+    onDragStart: undefined,
+    onDragEnd: undefined,
 }
 
 export default ReactSplitGrid

--- a/packages/react-split-grid/src/index.js
+++ b/packages/react-split-grid/src/index.js
@@ -23,6 +23,8 @@ class ReactSplitGrid extends React.Component {
         this.handleDragStart = this.handleDragStart.bind(this)
         this.writeStyle = this.writeStyle.bind(this)
         this.onDrag = this.onDrag.bind(this)
+        this.onDragStart = this.onDragStart.bind(this)
+        this.onDragEnd = this.onDragEnd.bind(this)
     }
 
     componentDidMount() {
@@ -30,6 +32,8 @@ class ReactSplitGrid extends React.Component {
 
         options.writeStyle = this.writeStyle
         options.onDrag = this.onDrag
+        options.onDragStart = this.onDragStart
+        options.onDragEnd = this.onDragEnd
 
         this.split = Split(options)
     }
@@ -121,6 +125,22 @@ class ReactSplitGrid extends React.Component {
 
         if (onDrag) {
             onDrag(direction, track, style)
+        }
+    }
+    
+    onDragStart(direction, track) {
+        const { onDragStart } = this.props
+
+        if (onDragStart) {
+            onDragStart(direction, track)
+        }
+    }
+    
+    onDragEnd(direction, track, style) {
+        const { onDragEnd } = this.props
+
+        if (onDragEnd) {
+            onDragEnd(direction, track)
         }
     }
 


### PR DESCRIPTION
In the current behavior, the `onDragStart` and `onDragEnd` props are passed directly to the `Split` constructor. When the functions for these props change, the new values don't get called which leads to incorrect behavior (i.e. on re-renders it accesses the old state).

This PR binds functions to these options the same way `onDrag` is currently handled to fix this issue.