### PR TITLE
Swap arrayOf with objectOf

### DIFF
--- a/packages/react-split-grid/src/index.js
+++ b/packages/react-split-grid/src/index.js
@@ -194,8 +194,8 @@ ReactSplitGrid.propTypes = {
     children: PropTypes.element,
     gridTemplateColumns: PropTypes.string,
     gridTemplateRows: PropTypes.string,
-    columnMinSizes: PropTypes.arrayOf(PropTypes.number),
-    rowMinSizes: PropTypes.arrayOf(PropTypes.number),
+    columnMinSizes: PropTypes.objectOf(PropTypes.number),
+    rowMinSizes: PropTypes.objectOf(PropTypes.number),
     onDrag: PropTypes.func,
 }
 


### PR DESCRIPTION
The prop type definition here requires an array of numbers but split-grid accepts an object of track ids and sizes.

This aligns the prop-types with the required input.