### PR TITLE
ensure typescript support to react-split-grid on import

### DIFF
--- a/packages/react-split-grid/package.json
+++ b/packages/react-split-grid/package.json
@@ -5,6 +5,7 @@
     "main": "dist/react-split-grid.js",
     "minified:main": "dist/react-split-grid.min.js",
     "module": "dist/react-split-grid.es.js",
+    "types": "./index.d.ts",
     "scripts": {
         "prepublish": "rollup -c",
         "build": "rollup -c && npm run size",
@@ -16,7 +17,8 @@
     "author": "Nathan Cahill <nathan@nathancahill.com>",
     "homepage": "https://split.js.org/",
     "files": [
-        "dist"
+        "dist",
+        "index.d.ts"
     ],
     "license": "MIT",
     "dependencies": {


### PR DESCRIPTION
index.d.ts is currently not packaged in the npm module and so this pull request ensures that both the file and explicit package.json reference to the type declaration is included in future npm publish builds.