### PR TITLE
[react-split] Add index.d.ts to files field of package.json

### DIFF
--- a/packages/react-split/package.json
+++ b/packages/react-split/package.json
@@ -17,7 +17,8 @@
     "author": "Nathan Cahill <nathan@nathancahill.com>",
     "homepage": "https://split.js.org/",
     "files": [
-        "dist"
+        "dist",
+        "index.d.ts"
     ],
     "license": "MIT",
     "dependencies": {


### PR DESCRIPTION
Resolves #572 #283

Thanks for maintaining an awesome package! As Clarence described in issue #572, we have been unable to resolve the type definition from the react-split that is published to the npm registry since `index.d.ts` is not listed `files` field of package.json.

![image](https://user-images.githubusercontent.com/19276905/129660274-857c4410-efc0-4395-bf17-4f0b20e54180.png)

This PR adds index.d.ts to the package.json's files field. I personally published the patch under [my scope](https://npm.im/@neetshin/react-split) and ensured that it works fine:

![image](https://user-images.githubusercontent.com/19276905/129659978-426730cb-ddb3-440f-8cb4-0a033e996bd1.png)


