### PR TITLE
Fix Gutter cursor on hover is lost after first drag

### DIFF
--- a/packages/splitjs/src/split.js
+++ b/packages/splitjs/src/split.js
@@ -489,7 +489,7 @@ const Split = (idsOption, options = {}) => {
         b.style.MozUserSelect = ''
         b.style.pointerEvents = ''
 
-        self.gutter.style.cursor = ''
+        self.gutter.style.cursor = cursor
         self.parent.style.cursor = ''
         document.body.style.cursor = ''
     }


### PR DESCRIPTION
Fix for Gutter cursor on hover is lost after first drag (https://github.com/nathancahill/split/issues/99)